### PR TITLE
ci: setup tsc workflow

### DIFF
--- a/.github/workflows/tsc.yml
+++ b/.github/workflows/tsc.yml
@@ -1,0 +1,21 @@
+name: TypeScript
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: TypeScript
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Node v14
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "a collaborative Discord bot for the binarysus server",
   "main": "./dist/index.js",
   "scripts": {
+		"build": "npx tsc",
     "lint": "npx eslint src",
     "flint": "npx eslint src --fix"
   },


### PR DESCRIPTION
this build will fail because of how the code requires `config.json`. get rid of it 
possible solution: use environment variables
