### PR TITLE
refactor: move away from default imports

### DIFF
--- a/src/commands/general/profile.ts
+++ b/src/commands/general/profile.ts
@@ -1,7 +1,8 @@
-import responses from "#constants/responses";
+import { PROFILE_NOT_FOUND } from "#constants/responses";
+import { fetchUser } from "#utils/fetchUser";
+import { buildProfileEmbed } from "#utils/profileEmbed";
 import type { Command } from "#types/Command";
-import fetchUser from "#utils/fetchUser";
-import profileEmbed from "#utils/profileEmbed";
+
 const command: Command = {
   name: "profile",
   description: "get the binarysearch profile of a user",
@@ -18,10 +19,10 @@ const command: Command = {
     const value = interaction.options.get("user")?.value;
     const data = await fetchUser(value as string);
     if(!data) {
-      interaction.reply(responses.PROFILE_NOT_FOUND);
+      interaction.reply({ content: PROFILE_NOT_FOUND, ephemeral: true });
     }
     else {
-      interaction.reply({ embeds: [profileEmbed(data)] });
+      interaction.reply({ embeds: [buildProfileEmbed(data)] });
     }
   }
 };

--- a/src/constants/emotes.ts
+++ b/src/constants/emotes.ts
@@ -1,4 +1,4 @@
-export default {
+export const difficultyEmotes = {
   "Easy": "<:bs_easy:863762378306486302>",
   "Medium": "<:bs_medium:863762378415538196>",
   "Hard": "<:bs_hard:863762378683318292>",

--- a/src/constants/questions.ts
+++ b/src/constants/questions.ts
@@ -1,4 +1,4 @@
-export default {
+export const questions = {
   "Easy": 212,
   "Medium": 570,
   "Hard": 223,

--- a/src/constants/responses.ts
+++ b/src/constants/responses.ts
@@ -1,3 +1,1 @@
-export default {
-  "PROFILE_NOT_FOUND": "Sorry, I could not find the user on binarysearch. Please note that usernames are case sensitive."
-};
+export const PROFILE_NOT_FOUND = "Sorry, I could not find the user on binarysearch. Please note that usernames are case sensitive.";

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -1,3 +1,1 @@
-export default {
-  "BINARYSEARCH_API": "https://binarysearch.com/api/users/USERNAME/profile"
-};
+export const BINARYSEARCH_API = "https://binarysearch.com/api/users/USERNAME/profile";

--- a/src/types/BSUser.ts
+++ b/src/types/BSUser.ts
@@ -6,7 +6,7 @@ interface Badge {
   count: number,
 }
 
-export default interface BSUser {
+export interface BSUser {
     id: number,
     username: string,
     isAdmin: boolean,

--- a/src/utils/fetchUser.ts
+++ b/src/utils/fetchUser.ts
@@ -1,9 +1,9 @@
 import fetch from "node-fetch";
-import BSUser from "#constants/bsUser";
-import urls from "#constants/urls";
+import { BINARYSEARCH_API } from "#constants/urls";
+import type { BSUser } from "#types/BSUser";
 
-export default async function fetchUser(username: string): Promise<null | BSUser> {
-  const url = urls.BINARYSEARCH_API.replace("USERNAME", username);
+export async function fetchUser(username: string): Promise<null | BSUser> {
+  const url = BINARYSEARCH_API.replace("USERNAME", username);
   const data = await fetch(url).then(res => res.json());
 
   if ("user" in data) return data.user;

--- a/src/utils/profileEmbed.ts
+++ b/src/utils/profileEmbed.ts
@@ -1,8 +1,8 @@
 import { MessageEmbed } from "discord.js";
 import { zero_width_space } from "#constants/unicodes";
-import BsUser from "#constants/bsUser";
-import emotes from "#constants/emotes";
-import questions from "#constants/questions";
+import { difficultyEmotes } from "#constants/emotes";
+import { questions } from "#constants/questions";
+import type { BSUser } from "#types/BSUser";
 
 enum Difficulty {
   Easy = "Easy",
@@ -18,11 +18,11 @@ function addProgressBar(difficulty: Difficulty, value: number, embed: MessageEmb
 
   embed.addField(
     `${difficulty} (${value} / ${questions[difficulty]})`,
-    zero_width_space + emotes[difficulty].repeat(d) + emotes["None"].repeat(12 - d)
+    zero_width_space + difficultyEmotes[difficulty].repeat(d) + difficultyEmotes["None"].repeat(12 - d)
   );
 }
 
-export default function(user: BsUser): MessageEmbed {
+export function buildProfileEmbed(user: BSUser): MessageEmbed {
   const { stat } = user;
 
   const embed = new MessageEmbed()


### PR DESCRIPTION
moved away from default imports to favour named imports for the sake of code consistency and flexibility.
additionally made some minor tweaks to mistakes that went unnoticed in a past PR [*cough cough*](https://github.com/binarysus/algo-chan/pull/11).