### PR TITLE
feat: add default embed color and progressive embed coloring for /profile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,13 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
+        "color-convert": "^2.0.1",
         "discord.js": "^13.0.1",
         "env-cmd": "^10.1.0",
         "node-fetch": "^2.6.1"
       },
       "devDependencies": {
+        "@types/color-convert": "^2.0.0",
         "@types/node-fetch": "^2.5.11",
         "@typescript-eslint/eslint-plugin": "^4.28.2",
         "@typescript-eslint/parser": "^4.28.2",
@@ -254,6 +256,21 @@
         "node": ">=14",
         "npm": ">=6"
       }
+    },
+    "node_modules/@types/color-convert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.0.tgz",
+      "integrity": "sha512-m7GG7IKKGuJUXvkZ1qqG3ChccdIM/qBBo913z+Xft0nKCX4hAU/IxKwZBU4cpRZ7GS5kV4vOblUkILtSShCPXQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/color-name": "*"
+      }
+    },
+    "node_modules/@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.8",
@@ -616,7 +633,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -627,8 +643,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -2205,6 +2220,21 @@
       "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.4.tgz",
       "integrity": "sha512-fFrlF/uWpGOX5djw5Mu2Hnnrunao75WGey0sP0J3jnhmrJ5TAPzHYOmytD5iN/+pMxS+f+u/gezqHa9tPhRHEA=="
     },
+    "@types/color-convert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.0.tgz",
+      "integrity": "sha512-m7GG7IKKGuJUXvkZ1qqG3ChccdIM/qBBo913z+Xft0nKCX4hAU/IxKwZBU4cpRZ7GS5kV4vOblUkILtSShCPXQ==",
+      "dev": true,
+      "requires": {
+        "@types/color-name": "*"
+      }
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.8",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz",
@@ -2443,7 +2473,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -2451,8 +2480,7 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "combined-stream": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -28,11 +28,13 @@
     "#utils/*": "./dist/utils/*.js"
   },
   "dependencies": {
+    "color-convert": "^2.0.1",
     "discord.js": "^13.0.1",
     "env-cmd": "^10.1.0",
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {
+    "@types/color-convert": "^2.0.0",
     "@types/node-fetch": "^2.5.11",
     "@typescript-eslint/eslint-plugin": "^4.28.2",
     "@typescript-eslint/parser": "^4.28.2",

--- a/src/commands/general/cpp.ts
+++ b/src/commands/general/cpp.ts
@@ -3,6 +3,7 @@ import { URL } from "url";
 
 import { cpp } from "#constants/cpp";
 import { CPPREFERENCE } from "#constants/urls";
+import { defaultEmbedColor } from "#constants/colors";
 import type { Command } from "#types/Command";
 import { lcsSort } from "#utils/lcsSort";
 
@@ -32,7 +33,8 @@ const command: Command = {
     const desc = matches.map((m, i) => `[\`${m}\`](${hrefs[i]})`).join("\n");
     const embed = new MessageEmbed()
       .setTitle("Search results")
-      .setDescription(desc);
+      .setDescription(desc)
+      .setColor(defaultEmbedColor);
 
     await interaction.reply({ embeds: [embed] });
   }

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -1,0 +1,2 @@
+export const defaultEmbedColor = 0x45c441;
+export const hslGreen = [120, 100, 50];

--- a/src/utils/profileEmbed.ts
+++ b/src/utils/profileEmbed.ts
@@ -1,7 +1,9 @@
 import { MessageEmbed } from "discord.js";
+import { hsl } from "color-convert";
 import { zero_width_space } from "#constants/unicodes";
 import { difficultyEmotes } from "#constants/emotes";
 import { questions } from "#constants/questions";
+import { hslGreen } from "#constants/colors";
 import type { BSUser } from "#types/BSUser";
 
 enum Difficulty {
@@ -25,11 +27,19 @@ function addProgressBar(difficulty: Difficulty, value: number, embed: MessageEmb
 export function buildProfileEmbed(user: BSUser): MessageEmbed {
   const { stat } = user;
 
+  // Uses hsl and converts to rgb for smooth color transitioning.
+  let [ h ] = hslGreen;
+  const [ , s, l ] = hslGreen;
+  // Transition from green to red on increasing level.
+  h = Math.floor(h - stat.grade * (h / 100));
+  const embedColor = hsl.rgb([h, s, l]);
+
   const embed = new MessageEmbed()
     .setTitle(user.username)
     .setURL(`https://binarysearch.com/@/${user.username}`)
     .addField("Level", `${stat.grade}`, true)
-    .addField("Experience", `${stat.xp}`, true);
+    .addField("Experience", `${stat.xp}`, true)
+    .setColor(embedColor);
 
   addProgressBar(Difficulty.Easy, stat.numEasySolved, embed);
   addProgressBar(Difficulty.Medium, stat.numMediumSolved, embed);


### PR DESCRIPTION
- Added a default embed color in `constants/colors.ts`.
- `/profile`'s embed color changes from green to red on increasing level.
- Added `color-convert` package for simple color format conversions.