### PR TITLE
refactor: change npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
 		"format:check": "npx prettier src -c",
 		"lint": "npx eslint src",
 		"start": "npx env-cmd node .",
-		"start:no-edit": "npx env-cmd node . --no-edit",
-		"start:type-change": "npx env-cmd node . --type-change"
+		"start:edit": "npx env-cmd node . --edit",
+		"start:type-change": "npx env-cmd node . --type-change",
+		"start:debug": "npx env-cmd node . --debug"
 	},
 	"repository": {
 		"type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,11 @@ const client = new Client({
 	intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MEMBERS, Intents.FLAGS.GUILD_MESSAGES]
 });
 
-client.logger = new Logger(LogLevel.INFO);
+let level = LogLevel.INFO;
+
+if (process.argv.includes("--debug")) level = LogLevel.DEBUG;
+
+client.logger = new Logger(level);
 
 startEventHandler(client);
 startCommandHandler(client);

--- a/src/internals/commandHandler.ts
+++ b/src/internals/commandHandler.ts
@@ -89,7 +89,7 @@ function startCommandHandler(client: Client) {
 		client.logger.info(`${slashCommands.size} slash command${plural(slashCommands.size)} loaded.`);
 		client.logger.info(`${contextCommands.size} context menu item${plural(contextCommands.size)} loaded.`);
 
-		if (!process.argv.includes("--no-edit")) {
+		if (process.argv.includes("--edit")) {
 			// Setting the commands as slash commands in the selected guild.
 			commandData = await setCommands(slashCommands, contextCommands);
 


### PR DESCRIPTION
- use `start:edit` instead of `start`.
- use `start` instead of `start:no-edit`.
- `start:debug` for debug logging.